### PR TITLE
Avoid the large blank rectangle on the task voting page.

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,11 +5,11 @@
 <% next if day.id == 0 -%>
 	<%= link_to_day(day, @day == day) %>
 <% end -%>
-	<div class="clear"></div>
+	<div style="clear: left;"></div>
 </div>
 <p>
-	If you want to work a certain task, place a bid on it by clicking the 
-	number on the right of the task description: 1 for high preference 
+	If you want to work a certain task, place a bid on it by clicking the
+	number on the right of the task description: 1 for high preference
 	(3/day), 2 for medium preference (10/day), 3 for low preference.
 </p>
 

--- a/public/stylesheets/client.css
+++ b/public/stylesheets/client.css
@@ -5,7 +5,7 @@ body{background:#ccc;}
 
 /* main view */
 #main{font-size: 9pt;width: 500px; padding:25px;}
-#main .clear{clear:both;}
+#main .clear{clear:left;}
 #main .space{margin:1em 0;height:1px;}
 #main .loading{background:url('/images/loading.gif') right no-repeat;}
 #main .l{text-align:left;}


### PR DESCRIPTION
The right-floated nav is overlapping the `clear`ed days list, causing a big white box. Only clearing left patches the problem.

An alternative and perhaps better solution would be to remove the 'clear' div altogether and set 'days' to `overflow: auto`.
